### PR TITLE
Fix HarmonyOS VPN IPv6 routing

### DIFF
--- a/entry/src/main/ets/entryability/ClashViewModel.ets
+++ b/entry/src/main/ets/entryability/ClashViewModel.ets
@@ -479,12 +479,18 @@ export class ClashViewModel {
       console.log(`AccessControl 将加载 acceptList ${acceptList.length} 个，rejectList ${rejectList.length} 个`)
       const accessControl = {
         tunIp : clashConfig?.tun?.["tun-ip"],
+        // Capture IPv6 at the VPN layer even when Mihomo DNS/outbound IPv6 remains disabled.
+        ipv6: true,
+        routeAddress: clashConfig?.["route-address"] ?? [],
         accessControl: { mode:appConfig?.accessControlMode ?? "", acceptList: acceptList, rejectList: rejectList } as AccessControl
       } as VpnRawOptions
       this.socketProxy.setOptionStates(accessControl)
     } else {
       const accessControl = {
         tunIp : clashConfig?.tun?.["tun-ip"],
+        // Capture IPv6 at the VPN layer even when Mihomo DNS/outbound IPv6 remains disabled.
+        ipv6: true,
+        routeAddress: clashConfig?.["route-address"] ?? [],
         accessControl: { mode:appConfig?.accessControlMode ?? "", acceptList: [], rejectList: [] } as AccessControl } as VpnRawOptions
       this.socketProxy.setOptionStates(accessControl)
     }

--- a/proxy_core/src/main/ets/rpc/CommonVpnService.ts
+++ b/proxy_core/src/main/ets/rpc/CommonVpnService.ts
@@ -4,9 +4,11 @@ import { common } from "@kit.AbilityKit";
 export class Address {
   address: string;
   family: number;
-  constructor(address: string, family: number) {
+  port: number;
+  constructor(address: string, family: number, port: number = 0) {
     this.address = address;
     this.family = family;
+    this.port = port;
   }
 }
 export  class AddressWithPrefix {
@@ -17,10 +19,21 @@ export  class AddressWithPrefix {
     this.prefixLength = prefixLength;
   }
 }
+export interface RouteInfo {
+  "interface": string;
+  destination: AddressWithPrefix;
+  gateway: Address;
+  hasGateway: boolean;
+  isDefaultRoute: boolean;
+  isExcludedRoute?: boolean;
+}
 export class VpnConfig {
   addresses: AddressWithPrefix[];
+  routes: RouteInfo[];
   mtu: number;
   dnsAddresses: string[];
+  isIPv4Accepted: boolean = true
+  isIPv6Accepted: boolean = false
   trustedApplications: string[] = []
   blockedApplications: string[] = []
   constructor(
@@ -30,6 +43,7 @@ export class VpnConfig {
     this.addresses = [
       new AddressWithPrefix(tunIp, 30)
     ];
+    this.routes = [];
     this.mtu = 1400;
     this.dnsAddresses = dnsAddresses;
   }
@@ -73,21 +87,48 @@ export abstract class CommonVpnService{
 }
 
 export function isIpv4(ip: string): Boolean {
-  let parts = ip.split("/")
-  if (parts.length != 2) {
-    return false
-  }
-  // TODO
-  return ip.length == 4
+  let address = ip.split("/")[0].trim()
+  return address.split(".").length == 4 && address.indexOf(":") == -1
 }
 
 export function isIpv6(ip: string): Boolean {
   let parts = ip.split("/")
-  if (parts.length != 2) {
-    return false
-  }
-  // TODO
-  return ip.length == 16
+  let address = parts[0].trim()
+  return address.indexOf(":") >= 0
 }
 
+export function cidrToAddressWithPrefix(cidr: string): AddressWithPrefix | null {
+  let parts = cidr.split("/")
+  if (parts.length != 2) {
+    return null
+  }
+  let address = parts[0].trim()
+  let prefixLength = parseInt(parts[1])
+  if (Number.isNaN(prefixLength)) {
+    return null
+  }
+  if (isIpv4(cidr)) {
+    return new AddressWithPrefix(new Address(address, 1), prefixLength)
+  }
+  if (isIpv6(cidr)) {
+    return new AddressWithPrefix(new Address(address, 2), prefixLength)
+  }
+  return null
+}
+
+export function cidrToRoute(cidr: string): RouteInfo | null {
+  let destination = cidrToAddressWithPrefix(cidr)
+  if (destination == null) {
+    return null
+  }
+  let family = destination.address.family
+  let gateway = family == 2 ? "fe80::" : "172.19.0.1"
+  return {
+    "interface": "vpn-tun",
+    destination: destination,
+    gateway: new Address(gateway, family),
+    hasGateway: false,
+    isDefaultRoute: cidr == "0.0.0.0/0" || cidr == "::/0",
+  }
+}
 

--- a/proxy_core/src/main/ets/rpc/FlClashVpnService.ts
+++ b/proxy_core/src/main/ets/rpc/FlClashVpnService.ts
@@ -22,7 +22,13 @@ import {
   startListener,
   stopListener
 } from 'libflclash.so';
-import { Address, CommonVpnService, isIpv4, isIpv6, VpnConfig } from './CommonVpnService';
+import {
+  Address,
+  AddressWithPrefix,
+  cidrToRoute,
+  CommonVpnService,
+  VpnConfig
+} from './CommonVpnService';
 import { JSON, util } from '@kit.ArkTS';
 import { RpcRequest, RpcResult } from './RpcRequest';
 import { ClashRpcType } from './IClashManager';
@@ -43,7 +49,7 @@ export interface VpnOptions {
   ipv4Address: string,
   ipv6Address: string,
   accessControl: AccessControl,
-  systemProxy: string,
+  systemProxy: boolean,
   allowBypass: boolean,
   routeAddress: string[],
   bypassDomain: string[],
@@ -98,21 +104,45 @@ export class FlClashVpnService extends CommonVpnService {
   ParseConfig(): VpnConfig {
     let vpnConfig = new VpnConfig();
     let option = JSON.parse(getVpnOptions()) as VpnOptions
+    if (option.ipv6Address == undefined || option.ipv6Address == "") {
+      option.ipv6Address = "fdfe:dcba:9876::1/126"
+    }
+    if (option.routeAddress == undefined) {
+      option.routeAddress = []
+    }
     if (option.ipv4Address != "") {
       const ips = option.ipv4Address.split("/")
       console.debug("tunIp ", ips)
-      if(ips.length > 1){
-        vpnConfig.addresses[0].address = new Address(ips[0], 1)
-        vpnConfig.addresses[0].prefixLength = parseInt(ips[1])
-      }else{
-        vpnConfig.addresses[0].address = new Address(ips[0], 1)
-      }
-      option.routeAddress?.filter(a => isIpv4(a)).map(f => f.split("/")[0])
+      const prefixLength = ips.length > 1 ? parseInt(ips[1]) : 30
+      vpnConfig.addresses[0] = new AddressWithPrefix(new Address(ips[0], 1), prefixLength)
+      vpnConfig.isIPv4Accepted = true
     }
     if (option.ipv6Address != "") {
-      vpnConfig.addresses[0].address = new Address(option.ipv6Address.split("/")[0], 2)
-      option.routeAddress?.filter(a => isIpv6(a)).map(f => f.split("/")[0])
+      const ips = option.ipv6Address.split("/")
+      const prefixLength = ips.length > 1 ? parseInt(ips[1]) : 126
+      vpnConfig.addresses.push(new AddressWithPrefix(new Address(ips[0], 2), prefixLength))
+      vpnConfig.isIPv6Accepted = true
     }
+    const routeAddresses: string[] = []
+    const addRouteAddress = (cidr: string) => {
+      if (cidr != "" && !routeAddresses.includes(cidr)) {
+        routeAddresses.push(cidr)
+      }
+    }
+    // Explicit defaults avoid OHOS auto-generating only fe80::/derived IPv6 coverage.
+    option.routeAddress?.forEach(addRouteAddress)
+    if (option.ipv4Address != "") {
+      addRouteAddress("0.0.0.0/0")
+    }
+    if (option.ipv6Address != "") {
+      addRouteAddress("::/0")
+    }
+    routeAddresses.forEach((cidr) => {
+      const route = cidrToRoute(cidr)
+      if (route != null) {
+        vpnConfig.routes.push(route)
+      }
+    })
     if (option.accessControl?.mode) {
       if (option.accessControl?.mode == "AcceptSelected") {
         vpnConfig.trustedApplications = option.accessControl?.acceptList

--- a/proxy_core/src/main/ets/rpc/IClashManager.ts
+++ b/proxy_core/src/main/ets/rpc/IClashManager.ts
@@ -43,6 +43,8 @@ export interface AccessControl{
 }
 export interface VpnRawOptions{
   tunIp: string
+  ipv6?: boolean
+  routeAddress?: string[]
   accessControl: AccessControl
 }
 


### PR DESCRIPTION
# Fix HarmonyOS VPN IPv6 routing

## Summary

This fixes a HarmonyOS VPN routing issue where IPv6 traffic from apps can bypass the VPN when the device has carrier IPv6 connectivity.

The change:

- passes IPv6 VPN state and custom route addresses into the native VPN option state
- adds IPv6 address and route modeling to the HarmonyOS `VpnConfig`
- adds explicit `0.0.0.0/0` and `::/0` VPN routes when IPv4/IPv6 tunnel addresses are configured
- keeps Mihomo DNS/outbound IPv6 policy separate from the VPN-layer IPv6 capture

## Root cause

The current HarmonyOS VPN config only effectively sets the IPv4 tunnel address. When apps open IPv6 connections on a network with public IPv6, the system may route those connections outside the ClashBox VPN.

OpenHarmony's VPN route generation also does not reliably create a full global IPv6 default route for this case, so this patch explicitly installs `::/0` into the app VPN route set.

## Validation

- Built locally through `CompileArkTS`
- Built locally through `PackageHap`
- Expected local failure at `SignHap` because the checked-in signing config points to a missing local debug `.p12`
- Installed a signed local HAP during debugging and verified:
  - `/proc/net/ipv6_route` contains an IPv6 default route through `vpn-tun`
  - browser traffic to an IPv6 literal destination appears in Mihomo `/connections` as `type=Tun` and uses the proxy chain

## Notes

This does not require enabling Mihomo DNS IPv6 resolution. The VPN captures IPv6 traffic at the system layer, while profile-level `ipv6: false` and `dns.ipv6: false` can still be used to prefer IPv4 proxy targets.
