### PR TITLE
Fix dns leakage by properly passing config of dns-hijack to TUN

### DIFF
--- a/proxy_core/src/flclash/lib_linux.go
+++ b/proxy_core/src/flclash/lib_linux.go
@@ -17,14 +17,15 @@ import (
 	"syscall"
 	"time"
 
+	"net"
+
 	"github.com/metacubex/mihomo/component/dialer"
+	"github.com/metacubex/mihomo/component/iface"
 	"github.com/metacubex/mihomo/component/process"
 	"github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/dns"
 	"github.com/metacubex/mihomo/listener/sing_tun"
 	"github.com/metacubex/mihomo/log"
-    "net"
-	"github.com/metacubex/mihomo/component/iface"
 )
 
 type ProcessMap struct {
@@ -89,7 +90,7 @@ func StartTUN(fd int, markSocket func(Fd)) {
 		tunLock.Lock()
 		defer tunLock.Unlock()
 		f := int(fd)
-		tunListener, _ = t.Start(f, currentConfig.General.Tun.Device, currentConfig.General.Tun.Stack)
+		tunListener, _ = t.Start(f, currentConfig.General.Tun.Device, currentConfig.General.Tun.Stack, currentConfig.General.Tun.DNSHijack)
 		if tunListener != nil {
 			log.Infoln("TUN address: %v", tunListener.Address())
 		}

--- a/proxy_core/src/flclash/tun/tun.go
+++ b/proxy_core/src/flclash/tun/tun.go
@@ -25,32 +25,33 @@ type Props struct {
 	Dns6     string `json:"dns6"`
 }
 
-func Start(fd int, device string, stack constant.TUNStack) (*sing_tun.Listener, error) {
+func Start(fd int, device string, stack constant.TUNStack, dnsHijack []string) (*sing_tun.Listener, error) {
 	var prefix4 []netip.Prefix
 	inet4Prefix4, err := netip.ParsePrefix(state.CurrentState.TunIp)
-	if (err == nil){
-	    prefix4 = append(prefix4, inet4Prefix4)
+	if err == nil {
+		prefix4 = append(prefix4, inet4Prefix4)
 	} else {
-	    tempPrefix4, err := netip.ParsePrefix(state.DefaultIpv4Address)
-    	if err != nil {
-    		log.Errorln("startTUN tempPrefix4 error:", err)
-    		return nil, err
-    	}
-    	prefix4 = append(prefix4, tempPrefix4)
+		tempPrefix4, err := netip.ParsePrefix(state.DefaultIpv4Address)
+		if err != nil {
+			log.Errorln("startTUN tempPrefix4 error:", err)
+			return nil, err
+		}
+		prefix4 = append(prefix4, tempPrefix4)
 	}
 	var prefix6 []netip.Prefix
 
 	if state.CurrentState.Ipv6 {
-        tempPrefix6, err := netip.ParsePrefix(state.DefaultIpv6Address)
-       if err != nil {
-           log.Errorln("startTUN  tempPrefix6 error:", err)
-           return nil, err
-       }
-       prefix6 = append(prefix6, tempPrefix6)
+		tempPrefix6, err := netip.ParsePrefix(state.DefaultIpv6Address)
+		if err != nil {
+			log.Errorln("startTUN  tempPrefix6 error:", err)
+			return nil, err
+		}
+		prefix6 = append(prefix6, tempPrefix6)
 	}
 
-	var dnsHijack []string
-	dnsHijack = append(dnsHijack, net.JoinHostPort(state.GetDnsServerAddress(), "53"))
+	if len(dnsHijack) == 0 {
+		dnsHijack = append(dnsHijack, net.JoinHostPort(state.GetDnsServerAddress(), "53"))
+	}
 
 	options := LC.Tun{
 		Enable:              true,


### PR DESCRIPTION
## Summary

The TUN listener was always hijacking DNS to the internal DNS server on port 53, ignoring any `dns-hijack` list the user set in their `tun:` config. This PR threads the configured `DNSHijack` value through to the TUN `Start` call and only falls back to the hardcoded default when the user hasn't specified one.

## Problem

In `proxy_core/src/flclash/tun/tun.go`, `Start` unconditionally built the hijack list from the internal DNS address:

```go
var dnsHijack []string
dnsHijack = append(dnsHijack, net.JoinHostPort(state.GetDnsServerAddress(), "53"))
```

Because `Start` never received the config value, anything a user put under `tun.dns-hijack` (e.g. `any:53`, `tcp://any:53`, `any:853`) was silently discarded. Only UDP:53 to the internal resolver was ever hijacked, so TCP DNS and non-standard DNS ports fell through unintercepted — a common DNS-leak vector.

## Fix

- `tun.Start` now accepts a `dnsHijack []string` parameter.
- The hardcoded default is applied only as a fallback when the passed list is empty:

  ```go
  if len(dnsHijack) == 0 {
      dnsHijack = append(dnsHijack, net.JoinHostPort(state.GetDnsServerAddress(), "53"))
  }
  ```

- `StartTUN` in `lib_linux.go` now passes `currentConfig.General.Tun.DNSHijack` into `Start`, so the parsed config value reaches the listener.

This preserves existing behavior for anyone who didn't set `dns-hijack` (they still get the internal-resolver default) while honoring the config for everyone who did.

## Files changed

- `proxy_core/src/flclash/lib_linux.go` — pass `Tun.DNSHijack` into `Start`; also tidies the import block (moves `net` into the stdlib group and `metacubex/mihomo/component/iface` into the mihomo group).
- `proxy_core/src/flclash/tun/tun.go` — add `dnsHijack []string` param; fallback-only default; plus gofmt cleanup on the `prefix4`/`prefix6` blocks (tabs and brace style).

## Testing

- [ ] Rebuild the mihomo core.
- [ ] With `any:53` set (the default config), confirm no port-53 traffic is observed passing through the TUN interface — indicating the UDP DNS queries are being intercepted/hijacked rather than forwarded out.
- [ ] With no dns-hijack set, confirmed default (internal resolver :53) still applies.